### PR TITLE
Use plain Bun for Docker

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,13 +13,8 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
 
-      - name: install nix
-        uses: cachix/install-nix-action@v27
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: build docker image
-        run: nix build -L .#dockerImage
+        run: docker build .
 
       - name: log in to github container registry
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM oven/bun:latest
 ADD ./ ./
-CMD ["bun", "run", "src/index.js"]
+RUN mkdir -p /data
+WORKDIR /data
+CMD ["bun", "run", "/home/bun/app/src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM oven/bun:latest
+ADD ./ ./
+CMD ["bun", "run", "src/index.js"]

--- a/readme.md
+++ b/readme.md
@@ -64,13 +64,13 @@ $ docker pull ghcr.io/oppiliappan/lurker:latest
 # quirk of using nix, it should not affect usage
 $ docker image ls
 REPOSITORY                   TAG       IMAGE ID       CREATED        SIZE
-ghcr.io/oppiliappan/lurker   latest    ba3733164889   54 years ago   186MB
+ghcr.io/oppiliappan/lurker   latest    ba3733164889   ???            227MB
 
 # start lurker in a container
 #
 # lurker stores data in /data,
 # so create a volume on the host accordingly:
-$ docker run -v /your/host/lurker-data:/data ghcr.io/oppiliappan/lurker:latest
+$ docker run -v /your/host/lurker-data:/data -p 3000 ghcr.io/oppiliappan/lurker:latest
 ```
 
 or with just [bun](https://bun.sh/):


### PR DESCRIPTION
Replaces `nix` build system with more transparent simple `bun` Dockerfile. Addresses #12 on my machine. Probably not a very satisfying  fix but thought I'd contribute it back nonetheless. 