### PR TITLE
[Feat] Card View

### DIFF
--- a/src/mixins/comment.pug
+++ b/src/mixins/comment.pug
@@ -12,6 +12,10 @@ mixin infoContainer(data, next_id, prev_id)
       if prev_id
         a(href=`#${prev_id}` title="scroll to previous comment").nav-link prev
         | &nbsp;·&nbsp;
+      if data.gilded > 0
+        span.gilded
+          | #{data.gilded} ☆
+        | &nbsp;·&nbsp;
       span(class=`${data.is_submitter ? 'op' : ''}`)
         | u/#{data.author} #{hats.length==0?'':`(${hats.join('|')})`}
       | &nbsp;·&nbsp;

--- a/src/mixins/comment.pug
+++ b/src/mixins/comment.pug
@@ -1,4 +1,5 @@
 include ../utils
+include postUtils
 
 mixin infoContainer(data, next_id, prev_id)
   - var hats = (data.is_submitter?['op']:[]).concat(data.distinguished=="moderator"?['mod']:[])
@@ -51,7 +52,7 @@ mixin comment(com, isfirst, parent_id, next_id, prev_id)
         summary.expand-comments
           +infoContainer(data, next_id, prev_id)
         div.comment-body
-          != data.body_html
+          != convertInlineImageLinks(data.body_html)
         if hasReplyData
           div.replies
             - var total = data.replies.data.children.length

--- a/src/mixins/comment.pug
+++ b/src/mixins/comment.pug
@@ -1,6 +1,7 @@
 include ../utils
 
 mixin infoContainer(data, next_id, prev_id)
+  - var hats = (data.is_submitter?['op']:[]).concat(data.distinguished=="moderator"?['mod']:[])
   div.comment-info-container
     p
       | #{fmtnum(data.ups)} ↑
@@ -12,7 +13,7 @@ mixin infoContainer(data, next_id, prev_id)
         a(href=`#${prev_id}` title="scroll to previous comment").nav-link prev
         | &nbsp;·&nbsp;
       span(class=`${data.is_submitter ? 'op' : ''}`)
-        | u/#{data.author} #{data.is_submitter ? '(op)' : ''}
+        | u/#{data.author} #{hats.length==0?'':`(${hats.join('|')})`}
       | &nbsp;·&nbsp;
       if data.collapsed_reason_code == "DELETED" || data.author == "[deleted]"
         a(href=`https://undelete.pullpush.io${data.permalink}`) search on undelete
@@ -21,6 +22,9 @@ mixin infoContainer(data, next_id, prev_id)
       | &nbsp;·&nbsp;
       if data.edited !== false
         | edited #{timeDifference(Date.now(), data.edited * 1000)} ago
+        | &nbsp;·&nbsp;
+      if data.stickied
+        | stickied
         | &nbsp;·&nbsp;
       a(href=`https://reddit.com${data.permalink}` title="view on reddit").nav-link open ↗
 
@@ -38,7 +42,7 @@ mixin comment(com, isfirst, parent_id, next_id, prev_id)
       a(href=`/comments/${parent_id}/comment/${data.id}`)
         | #{data.count} more #{fmttxt(data.count, 'comment')}
   else
-    div(class=`comment ${isfirst ? 'first' : ''}`)
+    div(class=`comment ${isfirst ? 'first' : ''} ${data.stickied ? 'sticky' : ''}`)
       details(id=`${data.id}` open="")
         summary.expand-comments
           +infoContainer(data, next_id, prev_id)

--- a/src/mixins/header.pug
+++ b/src/mixins/header.pug
@@ -1,16 +1,18 @@
 mixin header(user)
+  - var viewQuery = 'view=' + (query && query.view ? query.view : 'compact')
+  - var sortQuery = 'sort=' + (query ? (query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot') : 'hot')
   div.header
     div.header-item
-      a(href=`/`) home
+      a(href=`/?${sortQuery}&${viewQuery}`) home
     div.header-item
-      a(href=`/r/all`) all
+      a(href=`/r/all?${sortQuery}&${viewQuery}`) all
     div.header-item
-      a(href=`/search`) search
+      a(href=`/search?${sortQuery}&${viewQuery}`) search
     div.header-item
-      a(href=`/subs`) subs
+      a(href=`/subs?${sortQuery}&${viewQuery}`) subs
     if user
       div.header-item
-        a(href='/dashboard') #{user.username}
+        a(href=`/dashboard?${sortQuery}&${viewQuery}`) #{user.username}
         |&nbsp;
         a(href='/logout') (logout)
     else

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -2,11 +2,13 @@ include ../utils
 include postUtils
 mixin post(p, currentUrl)
   - var from = encodeURIComponent(currentUrl)
+  - var viewQuery = query && query.view ? query.view : 'compact'
+  - var sortQuery = query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
   article.post
-    div.post-container
-      div.post-text
-        div.title-container
-          a(href=`/comments/${p.id}?from=${from}`)
+    div.post-container(class=`${query.view}`)
+      div.post-text(class=`${query.view}`)
+        div.title-container(class=`${query.view}`)
+          a(class=`${query.view}`, href=`/comments/${p.id}?from=${from}&sort=${sortQuery}&view=${viewQuery}`)
             != p.title
           span.domain   (#{p.domain})
         div.info-container 
@@ -18,50 +20,73 @@ mixin post(p, currentUrl)
             | &nbsp;·&nbsp;
             | #{timeDifference(Date.now(), p.created * 1000)}
             | &nbsp;·&nbsp;
-            a(href=`/r/${p.subreddit}`) r/#{p.subreddit}
+            a(href=`/r/${p.subreddit}?sort=${sortQuery}&view=${viewQuery}`) r/#{p.subreddit}
             | &nbsp;·&nbsp;
-            a(href=`/comments/${p.id}?from=${from}`) #{fmtnum (p.num_comments)} ↩
-      div.media-preview
+            a(href=`/comments/${p.id}?from=${from}&sort=${sortQuery}&view=${viewQuery}`) #{fmtnum (p.num_comments)} ↩
+        if (query.view == "card" && !isPostGallery(p) && !isPostImage(p) && !isPostVideo(p) && p.selftext_html)
+          div.self-text-overflow(class='card')
+            if query.view == "card" && (p.spoiler || p.over_18)
+              div.spoiler(id=`spoiler_${p.id}`, onclick=`javascript:document.getElementById('spoiler_${p.id}').style.display = 'none';`)
+                h2
+                  != p.over_18 ? 'nsfw' : 'spoiler'
+            div.self-text(class='card')
+              != convertInlineImageLinks(p.selftext_html)
+      div.media-preview(class=`${query.view}`)
+        if query.view == "card" && (p.spoiler || p.over_18) && (isPostGallery(p) || isPostImage(p) || isPostVideo(p))
+          div.spoiler(id=`spoiler_${p.id}`, onclick=`javascript:document.getElementById('spoiler_${p.id}').style.display = 'none';`) 
+            h2
+              != p.over_18 ? 'nsfw' : 'spoiler'
         if isPostGallery(p)
           - var item = postGalleryItems(p)[0]
           img(src=item.url onclick=`toggleDetails('${p.id}')`) 
         else if isPostImage(p)
-          - var url = postThumbnail(p)
+          - var url = query.view == "card" ? p.url : postThumbnail(p)
           img(src=url onclick=`toggleDetails('${p.id}')`)
         else if isPostVideo(p)
-          - var url = p.secure_media.reddit_video.scrubber_media_url
-          video(src=url data-dashjs-player width='100px' height='100px' onclick=`toggleDetails('${p.id}')`)
+          - var decodedVideos = decodePostVideoUrls(p)
+          if query.view == "card"
+            video(controls="" muted="" data-dashjs-player="" preload="metadata" poster=decodedVideos[4])
+              // HLS
+              source(src=decodedVideos[0])
+              // Dash
+              source(src=decodedVideos[1])
+              // Fallback
+              source(src=decodedVideos[2])
+          else
+            video(autoplay="" muted="" data-dashjs-player="" onclick=`toggleDetails('${p.id}')` width="100px" height="100px")
+              // Scrubber
+              source(src=decodedVideos[3])
         else if isPostLink(p)
           a(href=p.url)
+            if (query.view == 'card')
+              | #{p.domain} 
             | ↗
 
-    if isPostGallery(p)
-      details(id=`${p.id}`)
-        summary.expand-post expand gallery
-        div.gallery
-          each item in postGalleryItems(p)
-            div.gallery-item
-              div.gallery-item-idx
-                | #{`${item.idx}/${item.total}`}
-              a(href=`/media/${item.url}`)
-                img(src=item.url loading="lazy")
-        button(onclick=`toggleDetails('${p.id}')`) close
-    else if isPostImage(p)
-      details(id=`${p.id}`)
-        summary.expand-post expand image
-        a(href=`/media/${p.url}`)
-          img(src=p.url loading="lazy").post-media
-        button(onclick=`toggleDetails('${p.id}')`) close
-    else if isPostVideo(p)
-      details(id=`${p.id}`)
-        summary.expand-post expand video
-        - var url = p.secure_media.reddit_video.dash_url
-        video(src=url controls data-dashjs-player loading="lazy").post-media
-        button(onclick=`toggleDetails('${p.id}')`) close
-    else if isPostLink(p)
-      details(id=`${p.id}`)
-        summary.expand-post expand link
-        a(href=`${p.url}`)
-          | #{p.url}
-        br
-        button(onclick=`toggleDetails('${p.id}')`) close
+  if (isPostGallery(p) || isPostImage(p) || isPostVideo(p))
+    details(id=`${p.id}`,class=`${query.view}`)
+      summary.expand-post expand media
+      div.image-viewer(class=`${query.view}`)
+        if isPostGallery(p)
+          div.gallery(class=`${query.view}`)
+            each item in postGalleryItems(p)
+              div.gallery-item(class=`${query.view}`)
+                div.gallery-item-idx(class=`${query.view}`)
+                  | #{`${item.idx}/${item.total}`}
+                a(href=`/media/${item.url}`)
+                  img(src=item.url loading="lazy")
+        else if isPostImage(p)
+          a(href=`/media/${p.url}`)
+            img(src=p.url loading="lazy").post-media
+        else if isPostVideo(p)
+          video(controls="" muted="" data-dashjs-player="" preload="metadata" playsinline="" poster=decodedVideos[4] objectfit="contain" loading="lazy").post-media
+              //HLS
+              source(src=decodedVideos[0])
+              // Dash
+              source(src=decodedVideos[1])
+              // Fallback
+              source(src=decodedVideos[2])
+        button(onclick=`toggleDetails('${p.id}')`,class=`${query.view}`)
+          if (query.view == 'card')
+            | ╳
+          else
+            | close

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -77,31 +77,28 @@ mixin post(p, currentUrl)
               | #{p.domain} 
             | ↗
 
-  if (isPostGallery(p) || isPostImage(p) || isPostVideo(p))
-    details(id=`${p.id}`,class=`${query.view}`)
-      summary.expand-post expand media
-      div.image-viewer(class=`${query.view}`)
-        if isPostGallery(p)
-          div.gallery(class=`${query.view}`)
-            each item in postGalleryItems(p)
-              div.gallery-item(class=`${query.view}`)
-                div.gallery-item-idx(class=`${query.view}`)
-                  | #{`${item.idx}/${item.total}`}
-                a(href=`/media/${item.url}`)
-                  img(src=item.url loading="lazy")
-        else if isPostImage(p)
-          a(href=`/media/${p.url}`)
-            img(src=p.url loading="lazy").post-media
-        else if isPostVideo(p)
-          video(controls="" muted="" data-dashjs-player="" preload="metadata" playsinline="" poster=decodedVideos[4] objectfit="contain" loading="lazy").post-media
-              //HLS
-              source(src=decodedVideos[0])
-              // Dash
-              source(src=decodedVideos[1])
-              // Fallback
-              source(src=decodedVideos[2])
-        button(onclick=`toggleDetails('${p.id}')`,class=`${query.view}`)
-          if (query.view == 'card')
-            | ╳
-          else
-            | close
+    if query.view == "compact" && (isPostGallery(p) || isPostImage(p) || isPostVideo(p))
+      details(id=`${p.id}`)
+        summary.expand-post expand media
+        div.image-viewer
+          if isPostGallery(p)
+            div.gallery
+              each item in postGalleryItems(p)
+                div.gallery-item
+                  div.gallery-item-idx
+                    | #{`${item.idx}/${item.total}`}
+                  a(href=`/media/${item.url}`)
+                    img(src=item.url loading="lazy")
+          else if isPostImage(p)
+            a(href=`/media/${p.url}`)
+              img(src=p.url loading="lazy").post-media
+          else if isPostVideo(p)
+            video(controls="" muted="" data-dashjs-player="" preload="metadata" playsinline="" poster=decodedVideos[4] objectfit="contain" loading="lazy").post-media
+                //HLS
+                source(src=decodedVideos[0])
+                // Dash
+                source(src=decodedVideos[1])
+                // Fallback
+                source(src=decodedVideos[2])
+          button(onclick=`toggleDetails('${p.id}')`)
+              | close

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -4,7 +4,7 @@ mixin post(p, currentUrl)
   - var from = encodeURIComponent(currentUrl)
   - var viewQuery = query && query.view ? query.view : 'compact'
   - var sortQuery = query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
-  article.post
+  article(class=`post ${p.stickied?"sticky":""}`)
     div.post-container(class=`${query.view}`)
       div.post-text(class=`${query.view}`)
         div.title-container(class=`${query.view}`)

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -14,6 +14,10 @@ mixin post(p, currentUrl)
         div.info-container 
           p
             | #{fmtnum(p.ups)} ↑ 
+            if p.gilded > 0
+              | &nbsp;·&nbsp;
+              span.gilded
+                | #{p.gilded} ☆
             span.post-author
               | &nbsp;·&nbsp;
               | u/#{p.author} 

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -4,8 +4,8 @@ mixin post(p, currentUrl)
   - var from = encodeURIComponent(currentUrl)
   - var viewQuery = query && query.view ? query.view : 'compact'
   - var sortQuery = query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
-  article(class=`post ${p.stickied?"sticky":""}`)
-    div.post-container(class=`${query.view}`)
+  article(class=`post`)
+    div.post-container(class=`${query.view} ${p.stickied?"sticky":""}`)
       div.post-text(class=`${query.view}`)
         div.title-container(class=`${query.view}`)
           a(class=`${query.view}`, href=`/comments/${p.id}?from=${from}&sort=${sortQuery}&view=${viewQuery}`)

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -36,16 +36,27 @@ mixin post(p, currentUrl)
             div.self-text(class='card')
               != convertInlineImageLinks(p.selftext_html)
       div.media-preview(class=`${query.view}`)
+        - var onclick = query.view != "card" ? `toggleDetails('${p.id}')` : ``
         if query.view == "card" && (p.spoiler || p.over_18) && (isPostGallery(p) || isPostImage(p) || isPostVideo(p))
           div.spoiler(id=`spoiler_${p.id}`, onclick=`javascript:document.getElementById('spoiler_${p.id}').style.display = 'none';`) 
             h2
               != p.over_18 ? 'nsfw' : 'spoiler'
         if isPostGallery(p)
           - var item = postGalleryItems(p)[0]
-          img(src=item.url onclick=`toggleDetails('${p.id}')`) 
+          if query.view == "card"
+            div.gallery(class=`${query.view}`)
+              each item in postGalleryItems(p)
+                div.gallery-item(class=`${query.view}`)
+                  div.gallery-item-idx(class=`${query.view}`)
+                    | #{`${item.idx}/${item.total}`}
+                  a(href=`/media/${item.url}`)
+                    img(src=item.url loading="lazy")
+          else
+            img(src=item.url onclick=onclick) 
         else if isPostImage(p)
           - var url = query.view == "card" ? p.url : postThumbnail(p)
-          img(src=url onclick=`toggleDetails('${p.id}')`)
+          #{query.view == "card" ? "a href=/media/" + url : span}
+            img(src=url onclick=onclick)
         else if isPostVideo(p)
           - var decodedVideos = decodePostVideoUrls(p)
           if query.view == "card"

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -47,10 +47,10 @@ mixin post(p, currentUrl)
             div.gallery(class=`${query.view}`)
               each item in postGalleryItems(p)
                 div.gallery-item(class=`${query.view}`)
-                  div.gallery-item-idx(class=`${query.view}`)
-                    | #{`${item.idx}/${item.total}`}
                   a(href=`/media/${item.url}`)
                     img(src=item.url loading="lazy")
+                  div.gallery-item-idx(class=`${query.view}`)
+                    | #{`${item.idx}/${item.total}`}
           else
             img(src=item.url onclick=onclick) 
         else if isPostImage(p)

--- a/src/mixins/postUtils.pug
+++ b/src/mixins/postUtils.pug
@@ -53,8 +53,9 @@
   }
 -
   function convertInlineImageLinks(html) {
-    // Find all anchors that href to https://preview.redd.it
-    const expression = /<a href="https:\/\/preview\.redd\.it.*?">(.*?)<\/a>/g;
+    // Find all anchors that href to preview.redd.it, i.redd.it, i.imgur.com
+    // and contain just a link to the same href
+    const expression = /<a href="(http[s]?:\/\/(?:preview\.redd\.it|i\.redd\.it|i\.imgur\.com).*?)">\1?<\/a>/g;
     const matches = html.matchAll(expression);
     var result = html;
     matches.forEach((match) => {

--- a/src/mixins/postUtils.pug
+++ b/src/mixins/postUtils.pug
@@ -60,7 +60,7 @@
     var result = html;
     matches.forEach((match) => {
       // Replace each occurrence with an actual img tag
-      result = result.replace(match[0], '<a href="' + match[1] + '"><img src="' + match[1] + '"></a>');
+      result = result.replace(match[0], '<a href="' + match[1] + '"><img class="inline" src="' + match[1] + '"></a>');
     })
 
     return result;

--- a/src/mixins/postUtils.pug
+++ b/src/mixins/postUtils.pug
@@ -10,14 +10,14 @@
   }
 -
   function postThumbnail(p) {
-    if (p.thumbnail == "image" || p.thumbnail == "") {
-        return p.url;
-    } else if (p.over_18) {
-        return "/nsfw.svg";
+    if (p.over_18) {
+      return "/nsfw.svg";
     } else if (p.thumbnail == "spoiler") {
-        return "/spoiler.svg";
+      return "/spoiler.svg";
+    } else if (p.thumbnail == "image" || p.thumbnail == "") {
+      return p.url;
     } else {
-        return p.thumbnail;
+      return p.thumbnail;
     }
   }
 -
@@ -50,4 +50,34 @@
     } else {
       return null;
     }
+  }
+-
+  function convertInlineImageLinks(html) {
+    // Find all anchors that href to https://preview.redd.it
+    const expression = /<a href="https:\/\/preview\.redd\.it.*?">(.*?)<\/a>/g;
+    const matches = html.matchAll(expression);
+    var result = html;
+    matches.forEach((match) => {
+      // Replace each occurrence with an actual img tag
+      result = result.replace(match[0], '<a href="' + match[1] + '"><img src="' + match[1] + '"></a>');
+    })
+
+    return result;
+  }
+-
+  function decodePostVideoUrls(p) {
+    // Video URLs have querystring separators that are HTML-encoded, so replace them.
+    const expression = /&amp;/g;
+
+    var hls_url = p.secure_media && p.secure_media.reddit_video && p.secure_media.reddit_video.hls_url ? p.secure_media.reddit_video.hls_url.replace(expression, '&') : '';
+
+    var dash_url = p.secure_media && p.secure_media.reddit_video && p.secure_media.reddit_video.dash_url ? p.secure_media.reddit_video.dash_url.replace(expression, '&') : '';
+
+    var fallback_url = p.secure_media && p.secure_media.reddit_video && p.secure_media.reddit_video.fallback_url ? p.secure_media.reddit_video.fallback_url.replace(expression, '&') : '';
+
+    var scrubber_url = p.secure_media && p.secure_media.reddit_video && p.secure_media.reddit_video.scrubber_media_url ? p.secure_media.reddit_video.scrubber_media_url.replace(expression, '&') : '';
+
+    var poster_url = p.preview && p.preview.images ? p.preview.images[0].source.url.replace(expression, '&') : '';
+
+    return [hls_url, dash_url, fallback_url, scrubber_url, poster_url];
   }

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -204,11 +204,8 @@ nav {
   align-items: center;
 }
 
-.gallery-item.card > a > img {
-  max-width: 95vw;
-  max-height: 30vh;
-  width: auto;
-  height: auto;
+.gallery-item.card {
+  max-width: 100%;
 }
 
 .spoiler {

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -51,6 +51,21 @@ body:has(details.card[open]) {
   overflow: hidden;
 }
 
+body.media-maximized {
+  /* Fix for Safari User Agent stylesheet */
+  margin: 0;
+}
+
+body.media-maximized.zoom,
+div.media-maximized.container.zoom {
+  overflow: auto;
+}
+
+img.media-maximized.zoom {
+  max-width: unset;
+  max-height: unset;
+}
+
 main {
   display: flex;
   flex-direction: column;
@@ -326,15 +341,6 @@ summary::before {
   padding: 1rem;
 }
 
-.media-maximized-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100vw;
-  height: 100vh;
-  overflow: hidden;
-}
-
 .media-maximized {
   max-width: 100vw;
   max-height: 100vh;
@@ -343,6 +349,15 @@ summary::before {
   display: block;
   margin: auto;
   object-fit: contain;
+}
+
+.media-maximized.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .post-author {

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -61,9 +61,14 @@ div.media-maximized.container.zoom {
   overflow: auto;
 }
 
+img.media-maximized {
+  cursor: zoom-in;
+}
+
 img.media-maximized.zoom {
   max-width: unset;
   max-height: unset;
+  cursor: zoom-out;
 }
 
 main {
@@ -193,41 +198,6 @@ nav {
 
 .media-preview.card > img {
   cursor: pointer;
-}
-
-.image-viewer.card {
-  /* Safari on iOS <= 17 */
-  -webkit-backdrop-filter: blur(2rem);
-  backdrop-filter: blur(2rem);
-  position: fixed;
-  inset: 0;
-  box-sizing: border-box;
-  display: flex;
-  height: 100%;
-  width: 100%;
-  justify-content: center;
-  align-items: center;
-  z-index: 100;
-}
-
-.image-viewer.card > button {
-  position: absolute;
-  top: 0;
-  right: 0;
-  margin: 1rem;
-  padding: initial;
-  height: 3rem;
-  width: 3rem;
-  font-size: 2rem;
-  border-radius: 100%;
-  cursor: pointer;
-}
-
-.image-viewer.card > a > img {
-  max-width: 100vw;
-  max-height: 100vh;
-  width: auto;
-  height: auto;
 }
 
 .gallery.card {

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -5,7 +5,8 @@
   --text-color: black;
   --text-color-muted: #999;
   --blockquote-color: green;
-  --sticky-color: lightgreen;
+  --sticky-color: #dcfeda;
+  --gilded: darkorange;
   --link-color: #29BC9B;
   --link-visited-color: #999;
   --accent: var(--link-color);
@@ -23,7 +24,8 @@
     --text-color: white;
     --text-color-muted: #999;
     --blockquote-color: lightgreen;
-    --sticky-color: #034611;
+    --sticky-color: #014413;
+    --gilded: gold;
     --link-color: #79ffe1;
     --link-visited-color: #999;
     --accent: var(--link-color);
@@ -654,6 +656,10 @@ a {
   color: var(--accent);
 }
 
+.gilded {
+  color: var(--gilded);
+}
+
 button {
   border: 0px solid;
   border-radius: 2px;
@@ -803,4 +809,3 @@ select {
   border-radius: 2px;
   border: 4px solid var(--sticky-color);
 }
-

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -82,6 +82,7 @@ main {
 .info-container a,
 .comment-info-container a,
 .sort-opts a,
+.view-opts a,
 .more a
 {
   text-decoration: none;
@@ -116,19 +117,26 @@ a:visited {
   align-items: center;
 }
 
-.sorting {
+.sorting,
+.viewing {
   margin-top: 20px;
 }
 
-.sort-opts {
+.sort-opts,
+.view-opts {
   display: grid;
   margin: 10px;
 }
 
-.sort-opts {
+.sort-opts,
+.view-opts {
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(5, 1fr);
   grid-auto-flow: column;
+}
+
+.view-opts {
+  grid-template-rows: repeat(2, 1fr);
 }
 
 .footer {
@@ -397,7 +405,8 @@ form {
   form {
     width: 40%;
   }
-  .sort-opts {
+  .sort-opts,
+  .view-opts {
     grid-template-columns: repeat(9, 1fr);
     grid-template-rows: repeat(1, 1fr);
     grid-auto-flow: row;
@@ -442,7 +451,8 @@ form {
   form {
     width: 20%;
   }
-  .sort-opts {
+  .sort-opts,
+  .view-opts {
     grid-template-columns: repeat(9, 1fr);
     grid-template-rows: repeat(1, 1fr);
     grid-auto-flow: row;
@@ -459,7 +469,8 @@ form {
   {
     max-height: 20vh;
   }
-  .sort-opts {
+  .sort-opts,
+  .view-opts {
     grid-template-columns: repeat(9, 1fr);
     grid-template-rows: repeat(1, 1fr);
     grid-auto-flow: row;
@@ -542,6 +553,7 @@ form {
 
 .header a,
 .sort-opts a,
+.view-opts a,
 .sub-title a {
   color: var(--text-color);
 }

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -141,7 +141,7 @@ nav {
 
 .post-container.card {
   border: 1px solid var(--bg-color-muted);
-  border-radius: 16px;
+  border-radius: 8px;
   display: block;
 }
 
@@ -299,7 +299,7 @@ summary::before {
 
 .media-preview.card img,
 .media-preview.card video {
-  border-radius: 16px;
+  border-radius: 6px;
 
   max-height: 40vh;
   max-width: 100%;

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -5,6 +5,7 @@
   --text-color: black;
   --text-color-muted: #999;
   --blockquote-color: green;
+  --sticky-color: lightgreen;
   --link-color: #29BC9B;
   --link-visited-color: #999;
   --accent: var(--link-color);
@@ -22,6 +23,7 @@
     --text-color: white;
     --text-color-muted: #999;
     --blockquote-color: lightgreen;
+    --sticky-color: #034611;
     --link-color: #79ffe1;
     --link-visited-color: #999;
     --accent: var(--link-color);
@@ -119,6 +121,10 @@ a:visited {
 nav {
   display: flex;
   align-items: stretch;
+}
+
+.post {
+  margin-bottom: 5px;
 }
 
 .post, .comments-container, .hero, .header, .footer {
@@ -791,3 +797,10 @@ select {
   text-indent: 1px;
   text-overflow: '';
 }
+
+.sticky {
+  background-color: var(--sticky-color);
+  border-radius: 2px;
+  border: 4px solid var(--sticky-color);
+}
+

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -809,3 +809,7 @@ select {
   border-radius: 2px;
   border: 4px solid var(--sticky-color);
 }
+
+.inline {
+  max-width: 100%;
+}

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -206,7 +206,7 @@ nav {
 
 .gallery-item.card > a > img {
   max-width: 95vw;
-  max-height: 95vh;
+  max-height: 30vh;
   width: auto;
   height: auto;
 }
@@ -231,6 +231,8 @@ nav {
   align-items: center;
 
   cursor: pointer;
+
+  z-index: 10;
 }
 
 .gallery-item-idx.card,

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -43,6 +43,10 @@ body {
   color: var(--text-color);
 }
 
+body:has(details.card[open]) {
+  overflow: hidden;
+}
+
 main {
   display: flex;
   flex-direction: column;
@@ -127,6 +131,120 @@ nav {
   font-size: 0.9rem;
 }
 
+.post-container.card {
+  border: 1px solid var(--bg-color-muted);
+  border-radius: 16px;
+  display: block;
+}
+
+.post-text.card {
+  padding: 0.9rem;
+  padding-top: 0.3rem;
+}
+
+.self-text-overflow.card {
+  /* For spoiler positioning */
+  position: relative;
+  padding-top: 0.3rem;
+  max-height: 10vh;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  display: block;
+}
+
+.self-text.card {
+  overflow: hidden;
+  display: -webkit-box;
+  /* Safari on iOS <= 17 */
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  text-overflow: ellipsis;
+}
+
+.media-preview.card {
+  position: relative;
+  padding: 0.3rem;
+  padding-bottom: 0.3rem;
+}
+
+.media-preview.card > img {
+  cursor: pointer;
+}
+
+.image-viewer.card {
+  /* Safari on iOS <= 17 */
+  -webkit-backdrop-filter: blur(2rem);
+  backdrop-filter: blur(2rem);
+  position: fixed;
+  inset: 0;
+  box-sizing: border-box;
+  display: flex;
+  height: 100%;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+}
+
+.image-viewer.card > button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 1rem;
+  padding: initial;
+  height: 3rem;
+  width: 3rem;
+  font-size: 2rem;
+  border-radius: 100%;
+  cursor: pointer;
+}
+
+.image-viewer.card > a > img {
+  max-width: 100vw;
+  max-height: 100vh;
+  width: auto;
+  height: auto;
+}
+
+.gallery.card {
+  align-items: center;
+}
+
+.gallery-item.card > a > img {
+  max-width: 95vw;
+  max-height: 95vh;
+  width: auto;
+  height: auto;
+}
+
+.spoiler {
+  background-color: rbga(var(--bg-color-muted), 0.2);
+  /* Safari on iOS <= 17 */
+  -webkit-backdrop-filter: blur(3rem);
+  backdrop-filter: blur(3rem);
+  border-radius: 4px;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  
+  box-sizing: border-box;
+  display: flex;
+  height: 100%;
+  width: 100%;
+  
+  justify-content: center;
+  align-items: center;
+
+  cursor: pointer;
+}
+
+.gallery-item-idx.card,
+.spoiler > h2 {
+  text-shadow: 0.1rem 0.1rem 1rem var(--bg-color-muted);
+}
+
 .comments-container {
   font-size: 0.9rem;
 }
@@ -169,6 +287,29 @@ summary::before {
   object-fit: cover;
   width: 4rem;
   height: 4rem;
+}
+
+.media-preview.card img,
+.media-preview.card video {
+  border-radius: 16px;
+
+  max-height: 40vh;
+  max-width: 100%;
+
+  display: block;
+  width: initial;
+  height: initial;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 1rem;
+
+  object-fit: fill;
+}
+
+.media-preview.card a {
+  font-size: 1.5rem;
+  margin: 1rem;
+  padding: initial;
 }
 
 .media-preview a {
@@ -225,6 +366,20 @@ form {
     width: 5rem;
     height: 5rem;
   }
+  .media-preview.card img,
+  .media-preview.card video
+  {
+    max-height: 50vh;
+  }
+  .media-preview.card a {
+    font-size: 1rem;
+    margin: 0.7rem;
+    padding: initial;
+  }
+  .self-text.card {
+    -webkit-line-clamp: 4;
+    line-clamp: 4;
+  }
   .post-author {
     display: inline
   }
@@ -252,9 +407,23 @@ form {
     width: 5rem;
     height: 5rem;
   }
+  .media-preview.card img,
+  .media-preview.card video
+  {
+    max-height: 30vh;
+  }
   .media-preview a {
     font-size: 2rem;
     padding: 2rem;
+  }
+  .media-preview.card a {
+    font-size: 1rem;
+    margin: 0.5rem;
+    padding: initial;
+  }
+  .self-text.card {
+    -webkit-line-clamp: 6;
+    line-clamp: 6;
   }
   .post-author {
     display: inline
@@ -276,6 +445,11 @@ form {
   .post, .comments-container, .hero, .header, .footer {
     flex: 1 1 40%;
     width: 40%;
+  }
+  .media-preview.card img,
+  .media-preview.card video
+  {
+    max-height: 20vh;
   }
   .sort-opts {
     grid-template-columns: repeat(9, 1fr);
@@ -343,6 +517,11 @@ form {
 .title-container > a {
   color: var(--text-color);
   text-decoration: none;
+}
+
+.title-container.card > a {
+  font-size: 1.125rem;
+  font-weight: bold;
 }
 
 .title-container > a:hover {

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -202,10 +202,17 @@ nav {
 
 .gallery.card {
   align-items: center;
+  scroll-snap-type: both mandatory;
 }
 
 .gallery-item.card {
   max-width: 100%;
+  width: 100%;
+  scroll-snap-align: center;
+}
+
+.gallery-item-idx.card {
+  text-align: center;
 }
 
 .spoiler {

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -288,27 +288,36 @@ summary::before {
   height: 4rem;
 }
 
+.media-preview.card {
+  padding: unset;
+}
+
 .media-preview.card img,
 .media-preview.card video {
   border-radius: 6px;
 
   max-height: 40vh;
-  max-width: 100%;
+  max-width: 95%;
 
   display: block;
-  width: initial;
-  height: initial;
+  width: unset;
+  height: unset;
   margin-left: auto;
   margin-right: auto;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 
   object-fit: fill;
 }
 
 .media-preview.card a {
   font-size: 1.5rem;
-  margin: 1rem;
-  padding: initial;
+  padding: unset;
+  padding-left: 1rem;
+}
+
+.media-preview.card a:has(img) {
+  font-size: 0rem;
+  padding: unset;
 }
 
 .media-preview a {

--- a/src/views/comments.pug
+++ b/src/views/comments.pug
@@ -6,6 +6,8 @@ include ../utils
 
 - var post = data.post
 - var comments = data.comments
+- var viewQuery = 'view=' + (query && query.view ? query.view : 'compact')
+- var sortQuery = 'sort=' + (query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot')
 doctype html
 html
   +head(post.title)
@@ -27,7 +29,7 @@ html
             | &nbsp;&nbsp;
             | ·
             | &nbsp;&nbsp;
-          a(href=`/r/${post.subreddit}`) r/#{post.subreddit}
+          a(href=`/r/${post.subreddit}?${sortQuery}&${viewQuery}`) r/#{post.subreddit}
 
         div.info-container 
           - var domain = (new URL(post.url)).hostname
@@ -65,7 +67,7 @@ html
 
         if post.selftext_html
           div.self-text
-            != post.selftext_html
+            != convertInlineImageLinks(post.selftext_html)
 
         hr
 

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -55,9 +55,9 @@ html
               a(href=`/r/${subreddit}?sort=top&t=year&view=${viewQuery}`) top year
             div
               a(href=`/r/${subreddit}?sort=top&t=all&view=${viewQuery}`) top all
-        details.sort-details
-          summary.sorting viewing as #{viewQuery}
-          div.sort-opts
+        details.view-details
+          summary.viewing viewing as #{viewQuery}
+          div.view-opts
             div
               a(href=`/r/${subreddit}?sort=${sortQuery}&view=compact`) compact
             div

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -16,9 +16,9 @@ html
         div.sub-title
           h1 
             if isMulti
-              a(href=`/?${sortQuery}&${viewQuery}`) lurker
+              a(href=`/?sort=${sortQuery}&view=${viewQuery}`) lurker
             else
-              a(href=`/r/${subreddit}?${sortQuery}&${viewQuery}`)
+              a(href=`/r/${subreddit}?sort=${sortQuery}&view=${viewQuery}`)
                 | r/#{subreddit}
           if !isMulti
             div#button-container

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -2,6 +2,8 @@ include ../mixins/post
 include ../mixins/header
 include ../mixins/head
 include ../utils
+  - var viewQuery = query && query.view ? query.view : 'compact'
+  - var sortQuery = query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
 doctype html
 html
   +head("home")
@@ -14,9 +16,9 @@ html
         div.sub-title
           h1 
             if isMulti
-              a(href=`/`) lurker
+              a(href=`/?${sortQuery}&${viewQuery}`) lurker
             else
-              a(href=`/r/${subreddit}`)
+              a(href=`/r/${subreddit}?${sortQuery}&${viewQuery}`)
                 | r/#{subreddit}
           if !isMulti
             div#button-container
@@ -32,27 +34,32 @@ html
             a(href="https://donate.stripe.com/dR62bTaZH1295Da4gg") oppiliappan
             |, author of lurker
         hr
-        details
-          summary.sorting sorting by #{query.sort + (query.t?' '+query.t:'')}
+        details.sort-details
+          summary.sorting sorting by #{query.sort + (query.t?' '+query.t:'')}, #{viewQuery} view
           div.sort-opts
             div
-              a(href=`/r/${subreddit}?sort=hot`) hot
+              a(href=`/r/${subreddit}?sort=hot&view=${viewQuery}`) hot
             div
-              a(href=`/r/${subreddit}?sort=new`) new
+              a(href=`/r/${subreddit}?sort=new&view=${viewQuery}`) new
             div
-              a(href=`/r/${subreddit}?sort=rising`) rising
+              a(href=`/r/${subreddit}?sort=rising&view=${viewQuery}`) rising
             div
-              a(href=`/r/${subreddit}?sort=top`) top
+              a(href=`/r/${subreddit}?sort=top&view=${viewQuery}`) top
             div
-              a(href=`/r/${subreddit}?sort=top&t=day`) top day
+              a(href=`/r/${subreddit}?sort=top&t=day&view=${viewQuery}`) top day
             div
-              a(href=`/r/${subreddit}?sort=top&t=week`) top week
+              a(href=`/r/${subreddit}?sort=top&t=week&view=${viewQuery}`) top week
             div
-              a(href=`/r/${subreddit}?sort=top&t=month`) top month
+              a(href=`/r/${subreddit}?sort=top&t=month&view=${viewQuery}`) top month
             div
-              a(href=`/r/${subreddit}?sort=top&t=year`) top year
+              a(href=`/r/${subreddit}?sort=top&t=year&view=${viewQuery}`) top year
             div
-              a(href=`/r/${subreddit}?sort=top&t=all`) top all
+              a(href=`/r/${subreddit}?sort=top&t=all&view=${viewQuery}`) top all
+          div.sort-opts
+            div
+              a(href=`/r/${subreddit}?sort=${sortQuery}&view=compact`) compact
+            div
+              a(href=`/r/${subreddit}?sort=${sortQuery}&view=card`) card
 
       if posts
         each child in posts.posts

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -35,7 +35,7 @@ html
             |, author of lurker
         hr
         details.sort-details
-          summary.sorting sorting by #{query.sort + (query.t?' '+query.t:'')}, #{viewQuery} view
+          summary.sorting sorting by #{query.sort + (query.t?' '+query.t:'')}
           div.sort-opts
             div
               a(href=`/r/${subreddit}?sort=hot&view=${viewQuery}`) hot
@@ -55,6 +55,8 @@ html
               a(href=`/r/${subreddit}?sort=top&t=year&view=${viewQuery}`) top year
             div
               a(href=`/r/${subreddit}?sort=top&t=all&view=${viewQuery}`) top all
+        details.sort-details
+          summary.sorting viewing as #{viewQuery}
           div.sort-opts
             div
               a(href=`/r/${subreddit}?sort=${sortQuery}&view=compact`) compact

--- a/src/views/media.pug
+++ b/src/views/media.pug
@@ -2,9 +2,14 @@ include ../mixins/head
 doctype html
 html
   +head("home")
-  body
-    div.media-maximized-container
+  script(type='text/javascript').
+    function toggleZoom() {
+      Array.from(document.getElementsByClassName('media-maximized')).forEach(element => element.classList.toggle('zoom'));
+    }
+
+  body.media-maximized
+    div.media-maximized.container
       if kind == 'img'
-        img(src=url).media-maximized
+        img(src=url onclick=`toggleZoom()`).media-maximized
       else
         video(src=url controls).media-maximized

--- a/src/views/post-search.pug
+++ b/src/views/post-search.pug
@@ -2,6 +2,8 @@ include ../mixins/post
 include ../mixins/header
 include ../mixins/head
 
+- var viewQuery = query && query.view ? query.view : 'compact'
+- var sortQuery = query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
 doctype html
 html
   +head("search posts")
@@ -14,6 +16,8 @@ html
         form(action="/post-search" method="get").search-bar
           - var prefill = original_query ?? "";
           input(type="text" name="q" placeholder="type in a search term..." value=prefill required).search-input
+          input(type="hidden" name="sort" value=sortQuery)
+          input(type="hidden" name="view" value=viewQuery)
           button(type="submit").search-button go
         if message
           div.search-message

--- a/src/views/search.pug
+++ b/src/views/search.pug
@@ -1,6 +1,8 @@
 include ../mixins/header
 include ../mixins/head
 
+- var viewQuery = query && query.view ? query.view : 'compact'
+- var sortQuery = query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
 doctype html
 html
   +head("search subreddits")
@@ -14,6 +16,8 @@ html
         form(action="/sub-search" method="get").search-bar
           - var prefill = original_query ?? "";
           input(type="text" name="q" placeholder="type in a search term..." value=prefill required).search-input
+          input(type="hidden" name="sort" value=sortQuery)
+          input(type="hidden" name="view" value=viewQuery)
           button(type="submit").search-button go
 
         hr
@@ -23,6 +27,8 @@ html
         form(action="/post-search" method="get").search-bar
           - var prefill = original_query ?? "";
           input(type="text" name="q" placeholder="type in a search term..." value=prefill required).search-input
+          input(type="hidden" name="sort" value=sortQuery)
+          input(type="hidden" name="view" value=viewQuery)
           button(type="submit").search-button go
         p 
           | you can narrow search results using filters:

--- a/src/views/sub-search.pug
+++ b/src/views/sub-search.pug
@@ -1,6 +1,8 @@
 include ../mixins/header
 include ../mixins/head
 
+- var viewQuery = (query && query.view) ? query.view : 'compact'
+- var sortQuery = (query && query.sort) ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
 doctype html
 html
   +head("search subreddits")
@@ -13,6 +15,8 @@ html
         form(action="/sub-search" method="get").search-bar
           - var prefill = original_query ?? "";
           input(type="text" name="q" placeholder="type in a search term..." value=prefill required).search-input
+          input(type="hidden" name="sort" value=sortQuery)
+          input(type="hidden" name="view" value=viewQuery)
           button(type="submit").search-button go
         if message
           div.search-message
@@ -25,7 +29,7 @@ html
                 - var isSubbed = subs.includes(subreddit)
                 div.sub-title
                   h3
-                    a(href=`/r/${subreddit}`) 
+                    a(href=`/r/${subreddit}?sort=${sortQuery}&view=${viewQuery}`) 
                       | r/#{subreddit}
                   div#button-container
                     if isSubbed

--- a/src/views/subs.pug
+++ b/src/views/subs.pug
@@ -1,6 +1,8 @@
 include ../mixins/header
 include ../mixins/head
 
+- var viewQuery = query && query.view ? query.view : 'compact'
+- var sortQuery = query && query.sort ? query.sort + (query.t ? '&t=' + query.t : '') : 'hot'
 doctype html
 html
   +head("subscriptions")
@@ -16,7 +18,7 @@ html
             - var isSubbed = true
             div.sub-title
               h4
-                a(href=`/r/${subreddit}`) 
+                a(href=`/r/${subreddit}?sort=${sortQuery}&view=${viewQuery}`) 
                   | r/#{subreddit}
               div#button-container
                 if isSubbed


### PR DESCRIPTION
Adds a  `card` view to lurker, while maintaining the current `compact` view by default.

- Closes #17 
- Displays post media in a larger media preview
- Click/tap to expand media
- For `self` posts, displays the first few lines of the post

<details><summary>Mobile</summary>
<p>

![Simulator Screenshot - iPhone 15 Pro - 2025-01-02 at 08 28 05](https://github.com/user-attachments/assets/a6ddfc46-c892-4d13-aefe-b4c8ef3c405c)
</p>
</details>
<details><summary>Desktop</summary>
<p>

![Screenshot 2025-01-02 at 8 18 26 AM](https://github.com/user-attachments/assets/b80511b0-6c78-41d7-bed4-4fc8aeab3468)
</p>
</details> 

There were a couple of small bugs I found while working on this that have been fixed as well:
- `nsfw` / `spoiler` checking didn't always correctly flag them when there was no thumbnail
- As part of making videos work in various browsers, fixed the URL parsing, so scrubber previews work in `compact` view
- As part of making the self text work in card view, updated the inline media parsing, so inline images work in the full thread view

Please review and let me know if there's anything you'd like to change, or bugs you find. A lot of work was put into retaining the existing `compact` view as-is, so there are a few hacked-together elements where I had to work around the existing code, but I don't believe it's an abomination or anything.