### PR TITLE
Add ARM64 build to docker publish workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,9 +13,6 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
 
-      - name: build docker image
-        run: docker build -t lurker:latest .
-
       - name: log in to github container registry
         uses: docker/login-action@v3
         with:
@@ -23,7 +20,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: publish docker image
-        run: |
-          docker tag lurker:latest ghcr.io/${{ github.repository_owner }}/lurker:latest
-          docker push ghcr.io/${{ github.repository_owner }}/lurker:latest
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: lurker:latest ghcr.io/${{ github.repository_owner }}/lurker:latest

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -33,4 +33,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: lurker:latest ghcr.io/${{ github.repository_owner }}/lurker:latest
+          tags: ghcr.io/${{ github.repository_owner }}/lurker:latest


### PR DESCRIPTION
This *should* enable an `arm64` build in the docker workflow; I've not yet run it locally myself though, just did it in the GitHub online editor cribbing from one of my previous projects. I'll give it a test later on unless someone gets to it first!

Resolves #11 