### PR TITLE
Fix video aspect ratio distortion in fullscreen mode

### DIFF
--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -300,6 +300,18 @@ summary::before {
   object-fit: fill;
 }
 
+video:-webkit-full-screen {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+video:fullscreen {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .image-viewer.main-content img,
 .image-viewer.main-content video {
   max-height: 70vh;


### PR DESCRIPTION
Use CSS fullscreen selectors to ensure videos maintain correct aspect ratio when played fullscreen in the browser.
It has been tested on Firefox 147.0.4 / Android 16. Further testing on other browsers and iOS would be better.
This patch has been done with the help of Claude Code (Opus 4.6)
Related to oppiliappan/lurker#30